### PR TITLE
feat(pdp): добавить SSR Product Details Page с доступной галереей

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^17.2.2",
         "drizzle-kit": "^0.31.4",
         "drizzle-orm": "^0.44.5",
+        "lucide-react": "0.542.0",
         "next": "15.5.2",
         "query-string": "^9.1.0",
         "react": "19.1.0",
@@ -5818,6 +5819,15 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.542.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz",
+      "integrity": "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
     "dotenv": "^17.2.2",
     "drizzle-kit": "^0.31.4",
     "drizzle-orm": "^0.44.5",
+    "lucide-react": "0.542.0",
     "next": "15.5.2",
+    "query-string": "^9.1.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "uuid": "^11.1.0",
     "zod": "^4.1.5",
-    "zustand": "^5.0.8",
-    "query-string": "^9.1.0"
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/(root)/products/[id]/page.tsx
+++ b/src/app/(root)/products/[id]/page.tsx
@@ -1,0 +1,193 @@
+import React from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { ShoppingBag, Heart, Star } from "lucide-react";
+import { products } from "@/lib/mock/products";
+import ProductGallery from "@/components/ProductGallery";
+import SizePicker from "@/components/SizePicker";
+import CollapsibleSection from "@/components/CollapsibleSection";
+import Card from "@/components/Card";
+
+type PageProps = { params: { id: string } };
+
+export default async function ProductDetailsPage({ params }: PageProps) {
+  const id = Number(params.id);
+  const product = products.find((p) => p.id === id);
+
+  // Простая заглушка, если продукт не найден
+  if (!product) {
+    return (
+      <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
+        <div className="py-24 text-center">
+          <h1 className="text-heading-2 text-dark-900 mb-2">
+            Product not found
+          </h1>
+          <p className="text-dark-700 mb-6">
+            The product you are looking for does not exist.
+          </p>
+          <Link
+            href="/products"
+            className="inline-block rounded-full bg-dark-900 text-light-100 px-5 py-3 text-button"
+          >
+            Back to Products
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  const discountPrice = product.price;
+  const compareAtPrice = Math.round(product.price * 1.2 * 100) / 100; // фиктивная скидка 20%
+  const discountPercent = Math.round(
+    ((compareAtPrice - discountPrice) / compareAtPrice) * 100
+  );
+
+  // Фиктивные изображения/варианты на основе public/shoes
+  const variantImages: Record<string, string[]> = {
+    default: [
+      product.imageSrc,
+      "/shoes/shoe-6.avif",
+      "/shoes/shoe-5.avif",
+      "/shoes/shoe-12.avif",
+      "/shoes/shoe-13.avif",
+    ],
+    pink: ["/shoes/shoe-10.avif", "/shoes/shoe-14.avif", "/shoes/shoe-15.avif"],
+    gray: ["/shoes/shoe-9.avif", "/shoes/shoe-8.avif"],
+    white: ["/shoes/shoe-1.jpg", "/shoes/shoe-2.webp"],
+  };
+
+  const swatches = [
+    { id: "default", label: "Default", bgClass: "bg-[#8a3145]" },
+    { id: "pink", label: "Pink", bgClass: "bg-[#e48ba1]" },
+    { id: "gray", label: "Gray", bgClass: "bg-[#8f8f8f]" },
+    { id: "white", label: "White", bgClass: "bg-[#eaeaea]" },
+  ];
+
+  const related = products.filter((p) => p.id !== product.id).slice(0, 3);
+
+  return (
+    <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-12">
+        <section>
+          <ProductGallery
+            imagesByVariant={variantImages}
+            swatches={swatches}
+            alt={product.title}
+          />
+        </section>
+
+        <section className="flex flex-col">
+          <div className="mb-4">
+            <p className="text-footnote text-dark-700">
+              {product.gender === "women"
+                ? "Women's Shoes"
+                : product.gender === "men"
+                ? "Men's Shoes"
+                : "Unisex"}
+            </p>
+            <h1 className="text-heading-2 text-dark-900 mt-1">
+              {product.title}
+            </h1>
+          </div>
+
+          <div className="mb-4 flex items-center gap-3">
+            <div className="text-heading-3 text-dark-900">
+              ${discountPrice.toFixed(2)}
+            </div>
+            <div className="text-dark-600 line-through">
+              ${compareAtPrice.toFixed(2)}
+            </div>
+            <span className="rounded-full bg-[color:oklch(0_0_0_/_0.06)] text-[--color-green] px-2 py-1 text-footnote">
+              Extra {discountPercent}% off
+            </span>
+          </div>
+
+          <div className="mt-2 mb-4">
+            <h2 className="text-heading-5 text-dark-900 mb-2">Select Size</h2>
+            <div className="flex items-center gap-2 mb-2">
+              <button
+                className="inline-flex items-center gap-2 rounded-full border border-dark-300 px-3 py-2 text-button text-dark-900"
+                aria-label="Size guide"
+              >
+                <Image
+                  src="/window.svg"
+                  alt="size guide"
+                  width={16}
+                  height={16}
+                />{" "}
+                Size Guide
+              </button>
+            </div>
+            <SizePicker
+              sizes={[
+                "5",
+                "5.5",
+                "6",
+                "6.5",
+                "7",
+                "7.5",
+                "8",
+                "8.5",
+                "9",
+                "9.5",
+                "10",
+              ]}
+            />
+          </div>
+
+          <div className="mt-2 flex flex-col gap-3">
+            <button className="inline-flex items-center justify-center gap-2 rounded-full bg-dark-900 text-light-100 px-6 py-4 text-button">
+              <ShoppingBag size={18} aria-hidden /> Add to Bag
+            </button>
+            <button className="inline-flex items-center justify-center gap-2 rounded-full bg-light-200 text-dark-900 px-6 py-4 text-button">
+              <Heart size={18} aria-hidden /> Favorite
+            </button>
+          </div>
+
+          <div className="mt-8 divide-y divide-light-300 border-t border-light-300">
+            <CollapsibleSection title="Product Details" defaultOpen>
+              <p className="text-dark-700">
+                The Air Max 90 stays true to its running roots with the iconic
+                Waffle sole, stitched overlays and textured accents.
+              </p>
+            </CollapsibleSection>
+            <CollapsibleSection title="Shipping & Returns">
+              <p className="text-dark-700">
+                Free standard shipping and 30-day returns.
+              </p>
+            </CollapsibleSection>
+            <CollapsibleSection title="Reviews (0)">
+              <div className="flex items-center gap-2 text-dark-700">
+                <Star size={16} /> No reviews yet.
+              </div>
+            </CollapsibleSection>
+          </div>
+        </section>
+      </div>
+
+      <section className="mt-16">
+        <h2 className="text-heading-3 text-dark-900 mb-6">
+          You Might Also Like
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {related.map((r) => (
+            <Card
+              key={r.id}
+              title={r.title}
+              subtitle={
+                r.gender === "women"
+                  ? "Women's Shoes"
+                  : r.gender === "men"
+                  ? "Men's Shoes"
+                  : "Unisex"
+              }
+              price={r.price}
+              imageSrc={r.imageSrc}
+              href={`/products/${r.id}`}
+            />
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(root)/products/page.tsx
+++ b/src/app/(root)/products/page.tsx
@@ -71,6 +71,7 @@ export default async function ProductsPage({
                       ? Number(p.price)
                       : undefined
                   }
+                  href={`/products/${p.id}`}
                 />
               ))}
             </div>

--- a/src/components/CollapsibleSection.tsx
+++ b/src/components/CollapsibleSection.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import React from "react";
+import { ChevronDown } from "lucide-react";
+
+export default function CollapsibleSection({
+  title,
+  children,
+  defaultOpen = false,
+}: {
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = React.useState<boolean>(defaultOpen);
+
+  return (
+    <section className="py-4">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between py-3 text-left"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <span className="text-heading-5 text-dark-900">{title}</span>
+        <ChevronDown
+          className={`transition-transform ${open ? "rotate-180" : "rotate-0"}`}
+          size={18}
+          aria-hidden
+        />
+      </button>
+      {open ? (
+        <div className="pt-2 text-body text-dark-800">{children}</div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/ProductGallery.tsx
+++ b/src/components/ProductGallery.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+import { Check, ImageOff } from "lucide-react";
+
+type VariantImages = Record<string, string[]>;
+
+type Swatch = {
+  id: string;
+  label: string;
+  bgClass: string; // tailwind class for background color
+};
+
+export default function ProductGallery({
+  imagesByVariant,
+  swatches,
+  alt,
+}: {
+  imagesByVariant: VariantImages;
+  swatches: Swatch[];
+  alt: string;
+}) {
+  const initialVariant = React.useMemo(() => {
+    const ids = Object.keys(imagesByVariant);
+    return ids[0] ?? "default";
+  }, [imagesByVariant]);
+
+  const [selectedVariantId, setSelectedVariantId] =
+    React.useState<string>(initialVariant);
+  const [selectedIndex, setSelectedIndex] = React.useState<number>(0);
+
+  const broken = React.useRef<Set<string>>(new Set());
+
+  const allImages = React.useMemo(() => {
+    const arr = imagesByVariant[selectedVariantId] ?? [];
+    // фильтруем известные сломанные изображения
+    return arr.filter((src) => !broken.current.has(src));
+  }, [imagesByVariant, selectedVariantId]);
+
+  React.useEffect(() => {
+    setSelectedIndex(0);
+  }, [selectedVariantId]);
+
+  const currentSrc = allImages[selectedIndex];
+  const [loaded, setLoaded] = React.useState<boolean>(false);
+
+  const handleMainError = () => {
+    if (currentSrc) {
+      broken.current.add(currentSrc);
+      const candidate = allImages.find((src) => !broken.current.has(src));
+      const nextIdx = candidate ? allImages.indexOf(candidate) : -1;
+      setSelectedIndex(nextIdx >= 0 ? nextIdx : 0);
+    }
+  };
+
+  const onKeyMain = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (allImages.length === 0) return;
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setSelectedIndex((i) => (i + 1) % allImages.length);
+    }
+    if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setSelectedIndex((i) => (i - 1 + allImages.length) % allImages.length);
+    }
+  };
+
+  return (
+    <div className="w-full">
+      {/* Swatches */}
+      {swatches?.length ? (
+        <div className="mb-4 flex items-center gap-3">
+          {swatches.map((s) => {
+            const selected = s.id === selectedVariantId;
+            return (
+              <button
+                key={s.id}
+                type="button"
+                aria-label={s.label}
+                aria-pressed={selected}
+                onClick={() => setSelectedVariantId(s.id)}
+                className={`relative h-9 w-9 rounded-full border border-light-300 focus:outline-none focus:ring-2 focus:ring-dark-900 ${s.bgClass}`}
+              >
+                {selected ? (
+                  <span className="absolute inset-0 grid place-items-center">
+                    <Check size={16} className="text-dark-900" />
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[80px_1fr] lg:gap-4">
+        {/* Thumbs (desktop left) */}
+        <div className="hidden lg:block">
+          <div className="flex lg:flex-col gap-2 overflow-auto max-h-[520px] pr-1">
+            {allImages.length ? (
+              allImages.map((src, idx) => {
+                const isActive = idx === selectedIndex;
+                return (
+                  <button
+                    key={src + idx}
+                    type="button"
+                    onClick={() => setSelectedIndex(idx)}
+                    className={`relative aspect-square w-20 overflow-hidden rounded-md border ${
+                      isActive ? "border-dark-900" : "border-light-300"
+                    } focus:outline-none focus:ring-2 focus:ring-dark-900`}
+                  >
+                    <Image
+                      src={src}
+                      alt="thumbnail"
+                      fill
+                      sizes="80px"
+                      className="object-cover"
+                      onError={() => {
+                        broken.current.add(src);
+                      }}
+                    />
+                  </button>
+                );
+              })
+            ) : (
+              <div className="grid place-items-center aspect-square w-20 rounded-md bg-light-200 text-dark-600">
+                <ImageOff size={20} />
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Main image */}
+        <div
+          tabIndex={0}
+          onKeyDown={onKeyMain}
+          className="relative aspect-square w-full overflow-hidden rounded-xl bg-light-200 outline-none focus:ring-2 focus:ring-dark-900"
+        >
+          {currentSrc ? (
+            <>
+              {!loaded ? (
+                <div className="absolute inset-0 animate-pulse bg-light-300" />
+              ) : null}
+              <Image
+                src={currentSrc}
+                alt={alt}
+                fill
+                sizes="(min-width: 1024px) 50vw, 100vw"
+                className="object-cover"
+                onError={handleMainError}
+                onLoadingComplete={() => setLoaded(true)}
+                priority
+              />
+            </>
+          ) : (
+            <div className="absolute inset-0 grid place-items-center text-dark-600">
+              <ImageOff size={28} />
+            </div>
+          )}
+        </div>
+
+        {/* Thumbs (mobile bottom) */}
+        <div className="lg:hidden">
+          <div className="mt-2 flex gap-2 overflow-x-auto pb-1">
+            {allImages.length ? (
+              allImages.map((src, idx) => {
+                const isActive = idx === selectedIndex;
+                return (
+                  <button
+                    key={src + idx}
+                    type="button"
+                    onClick={() => setSelectedIndex(idx)}
+                    className={`relative aspect-square w-20 flex-shrink-0 overflow-hidden rounded-md border ${
+                      isActive ? "border-dark-900" : "border-light-300"
+                    } focus:outline-none focus:ring-2 focus:ring-dark-900`}
+                  >
+                    <Image
+                      src={src}
+                      alt="thumbnail"
+                      fill
+                      sizes="80px"
+                      className="object-cover"
+                      onError={() => {
+                        broken.current.add(src);
+                      }}
+                    />
+                  </button>
+                );
+              })
+            ) : (
+              <div className="grid place-items-center aspect-square w-20 rounded-md bg-light-200 text-dark-600">
+                <ImageOff size={20} />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SizePicker.tsx
+++ b/src/components/SizePicker.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import React from "react";
+
+export default function SizePicker({ sizes }: { sizes: string[] }) {
+  const [active, setActive] = React.useState<string | null>(null);
+
+  const onKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!sizes.length) return;
+    const idx = active ? sizes.indexOf(active) : 0;
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      e.preventDefault();
+      const next = sizes[(idx + 1) % sizes.length];
+      setActive(next);
+    }
+    if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      e.preventDefault();
+      const prev = sizes[(idx - 1 + sizes.length) % sizes.length];
+      setActive(prev);
+    }
+  };
+
+  return (
+    <div
+      className="grid grid-cols-5 gap-2"
+      role="listbox"
+      aria-label="Select size"
+      tabIndex={0}
+      onKeyDown={onKey}
+    >
+      {sizes.map((size) => {
+        const selected = active === size;
+        return (
+          <button
+            key={size}
+            type="button"
+            role="option"
+            aria-selected={selected}
+            onClick={() => setActive(size)}
+            className={`rounded-md border px-3 py-2 text-button ${
+              selected
+                ? "border-dark-900 bg-dark-900 text-light-100"
+                : "border-light-300 bg-light-100 text-dark-900"
+            } focus:outline-none focus:ring-2 focus:ring-dark-900`}
+          >
+            {size}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,3 +3,6 @@ export { default as Navbar } from "./Navbar";
 export { default as Footer } from "./Footer";
 export { default as AuthForm } from "./AuthForm";
 export { default as SocialProviders } from "./SocialProviders";
+export { default as ProductGallery } from "./ProductGallery";
+export { default as SizePicker } from "./SizePicker";
+export { default as CollapsibleSection } from "./CollapsibleSection";


### PR DESCRIPTION
Реализована полноценная страница карточки товара (PDP) с серверным рендерингом и изолированными клиентскими компонентами для интерактивных частей (галерея, свотчи, выбор размеров, аккордеоны). Страница строго следует макету и адаптивна для desktop/tablet/mobile.

Что сделано
- Добавлен динамический маршрут:
  - src/app/(root)/products/[id]/page.tsx (Server Component)
- Галерея товара (Client):
  - src/components/ProductGallery.tsx
  - Основное изображение + превью (вертикальные на desktop, горизонтальный скролл на mobile)
  - Клавиатурная навигация (стрелки), focus-ring, aria-атрибуты
  - Фильтрация/пропуск битых изображений; фолбэк с ImageOff
  - Скелет при загрузке главного изображения
  - Свотчи вариантов с индикацией выбора (Lucide Check)
- Выбор размера (Client):
  - src/components/SizePicker.tsx
  - Управление клавиатурой (стрелки), role=listbox/option
- Секции-аккордеоны (Client):
  - src/components/CollapsibleSection.tsx
  - Доступность: aria-expanded, визуальная индикация
- Мета-данные товара (Server):
  - Заголовок, цена, сравнение, бейдж скидки
  - Кнопки “Add to Bag” и “Favorite” (UI-only)
  - “You Might Also Like” — грид из статичных товаров (Card)
- Навигация:
  - Обновлён список товаров: карточки теперь ведут на /products/[id] src/app/(root)/products/page.tsx
- Экспорты:
  - src/components/index.ts — экспорты новых компонентов
- Зависимости:
  - Добавлен lucide-react (иконки Heart/ShoppingBag/Star/Check/ChevronDown)
- Косметика:
  - Мелкая правка многострочных JSX-блоков для читаемости

Почему
- Требование: пиксель-перфект PDP c SSR, доступной галереей и изолированным клиентским интерактивом. Единообразный UX и навигация из карточек.

Производительность
- next/image с указанием sizes для избежания CLS
- SSR для всего статического UI, клиент — только для интерактива
- Пропуск битых изображений снижает лишние перерисовки/ошибки

Доступность
- Видимые focus-ring, role/aria-атрибуты для галереи и выбора размера
- Навигация клавиатурой (стрелки), корректные состояния pressed/selected

Адаптивность
- Desktop layout — строго по макету
- Tablet/Mobile — галерея сверху, горизонтальные превью, одноколоночный контент

План проверки (manual)
1) Открыть /products — клик по карточке ведёт на /products/:id. 2) Проверить галерею:
   - Стрелки клавиатуры переключают изображение
   - Клик по превью меняет главное фото
   - При битом src отображается фолбэк с ImageOff 3) Свотчи — изменение варианта переключает набор картинок 4) SizePicker — выбор кликом и клавишами, видимая индикация 5) Аккордеоны — корректный toggle, aria-expanded
6) Проверить разные брейкпоинты (mobile/tablet/desktop) на совпадение с макетом 7) “You Might Also Like” — карточки кликабельны, ведут на PDP

Обновления окружения
- После pull выполнить: npm install (добавлен lucide-react)

Breaking changes
- Нет

Refs: PDP SSR, accessibility, responsive UI