### PR TITLE
feat(pdp): SSR Product Details Page + доступная галерея\n\nРеализован…

### DIFF
--- a/src/components/ProductGallery.tsx
+++ b/src/components/ProductGallery.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import Image from "next/image";
-import { Check, ImageOff } from "lucide-react";
+import { Check, ImageOff, ChevronLeft, ChevronRight } from "lucide-react";
 
 type VariantImages = Record<string, string[]>;
 
@@ -96,7 +96,7 @@ export default function ProductGallery({
       <div className="grid grid-cols-1 gap-3 lg:grid-cols-[80px_1fr] lg:gap-4">
         {/* Thumbs (desktop left) */}
         <div className="hidden lg:block">
-          <div className="flex lg:flex-col gap-2 overflow-auto max-h-[520px] pr-1">
+          <div className="flex lg:flex-col gap-2 overflow-y-auto overflow-x-hidden max-h-[520px] pr-1">
             {allImages.length ? (
               allImages.map((src, idx) => {
                 const isActive = idx === selectedIndex;
@@ -151,6 +151,32 @@ export default function ProductGallery({
                 onLoadingComplete={() => setLoaded(true)}
                 priority
               />
+              {allImages.length > 1 ? (
+                <div className="absolute bottom-3 right-3 flex items-center gap-2">
+                  <button
+                    type="button"
+                    aria-label="Previous image"
+                    onClick={() =>
+                      setSelectedIndex(
+                        (i) => (i - 1 + allImages.length) % allImages.length
+                      )
+                    }
+                    className="grid h-9 w-9 place-items-center rounded-full border border-light-300 bg-light-100/90 text-dark-900 shadow-sm backdrop-blur focus:outline-none focus:ring-2 focus:ring-dark-900"
+                  >
+                    <ChevronLeft size={16} />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Next image"
+                    onClick={() =>
+                      setSelectedIndex((i) => (i + 1) % allImages.length)
+                    }
+                    className="grid h-9 w-9 place-items-center rounded-full border border-light-300 bg-light-100/90 text-dark-900 shadow-sm backdrop-blur focus:outline-none focus:ring-2 focus:ring-dark-900"
+                  >
+                    <ChevronRight size={16} />
+                  </button>
+                </div>
+              ) : null}
             </>
           ) : (
             <div className="absolute inset-0 grid place-items-center text-dark-600">


### PR DESCRIPTION
…а полноценная PDP: серверный рендер, клиентские компоненты для интерактива (галерея, свотчи, выбор размеров, аккордеоны).\n\nЧто сделано\n- Динамический маршрут: src/app/(root)/products/[id]/page.tsx (Server Component)\n- Галерея товара (Client): src/components/ProductGallery.tsx\n  • Основное изображение + превью (вертикальные на desktop, горизонтальный скролл на mobile)\n  • Навигация стрелками и фокус с клавиатуры, aria-атрибуты\n  • Пропуск битых изображений + фолбэк ImageOff; скелет загрузки\n  • Свотчи вариантов с Lucide Check\n- Выбор размера (Client): src/components/SizePicker.tsx (role=listbox/option, клавиатура)\n- Секции-аккордеоны (Client): src/components/CollapsibleSection.tsx (aria-expanded)\n- Мета-данные: цена, сравнение, скидка, кнопки Add to Bag/Favorite (UI-only)\n- Related: “You Might Also Like” через Card с серверного рендера\n- Навигация: карточки ведут на /products/[id] (обновлён products/page.tsx)\n- Экспорты: добавлены в src/components/index.ts\n- Зависимости: lucide-react\n\nПравки по ревью\n- Убран горизонтальный скролл у вертикальных превью (overflow-y-auto, overflow-x-hidden)\n- Добавлены кнопки-стрелки в главной картинке для листания изображений\n\nPerf/UX/A11y\n- next/image с sizes для снижения CLS\n- SSR для статического UI; клиент — только интерактив\n- Видимые focus-ring, корректные aria, клавиатурная навигация\n\nBREAKING CHANGE: нет